### PR TITLE
Update TextMesh Pro.meta

### DIFF
--- a/Assets/TextMesh Pro.meta
+++ b/Assets/TextMesh Pro.meta
@@ -5,4 +5,55 @@ DefaultImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 
+  assetBundleVariant:
+#!/usr/bin/env python3
+"""
+Demonstrates how to parse and modify a Unity .meta file in YAML.
+Requires PyYAML: pip install PyYAML
+"""
+
+import yaml
+
+yaml_input = r"""fileFormatVersion: 2
+guid: f54d1bd14bd3ca042bd867b519fee8cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
   assetBundleVariant: 
+"""
+
+def main():
+    # Parse the YAML text
+    data = yaml.safe_load(yaml_input)
+    
+    # data is likely a dict: {
+    #   'fileFormatVersion': 2,
+    #   'guid': 'f54d1bd14bd3ca042bd867b519fee8cc',
+    #   'folderAsset': 'yes',
+    #   'DefaultImporter': {
+    #       'externalObjects': {},
+    #       'userData': None,
+    #       'assetBundleName': None,
+    #       'assetBundleVariant': None
+    #   }
+    # }
+    
+    print("[Original Data]:", data)
+
+    # Example: update the GUID
+    data['guid'] = "1234567890abcdef1234567890abcdef"  # a new 32-char hex string
+    
+    # Optionally set an assetBundleName
+    if 'DefaultImporter' in data and isinstance(data['DefaultImporter'], dict):
+        data['DefaultImporter']['assetBundleName'] = "my_bundle"
+    
+    # Dump updated data back to YAML
+    updated_yaml = yaml.dump(data, sort_keys=False)
+    
+    print("\n[Updated YAML]:\n")
+    print(updated_yaml)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. Verify Understanding You’ve provided a Unity .meta file snippet, which typically looks like this for a folder or an asset:

yaml
Copy code
fileFormatVersion: 2
guid: f54d1bd14bd3ca042bd867b519fee8cc
folderAsset: yes
DefaultImporter:
  externalObjects: {}
  userData: 
  assetBundleName: 
  assetBundleVariant:
Unity automatically generates these .meta files to track GUIDs, import settings, and references for each asset or folder. Sometimes you may want to programmatically parse or modify these .meta files (e.g., enforcing consistent GUID usage across multiple projects, or bulk updating asset bundle names).

Since this snippet is in YAML format, you can parse or manipulate it using your favorite YAML library (like PyYAML in Python).

2. Outline Approach Read the .meta file as a normal YAML string.
Use a YAML parser to load it into a Python dictionary. Modify fields as needed (e.g., guid or assetBundleName). Dump it back to a YAML string, preserving or re-injecting any custom lines that Unity might require. While .meta files typically only have a small set of keys, you can store your modifications or validations in a pipeline script.

3. Example Python Script Below is an illustrative script that reads your snippet, updates the guid, and optionally sets an assetBundleName. It prints out the updated YAML to stdout. In a real-world scenario, you’d write it back to disk in place of the old .meta file.

python
Copy code
#!/usr/bin/env python3
"""
Demonstrates how to parse and modify a Unity .meta file in YAML. Requires PyYAML: pip install PyYAML
"""

import yaml

yaml_input = r"""fileFormatVersion: 2
guid: f54d1bd14bd3ca042bd867b519fee8cc
folderAsset: yes
DefaultImporter:
  externalObjects: {}
  userData: 
  assetBundleName: 
  assetBundleVariant: 
"""

def main():
    # Parse the YAML text
    data = yaml.safe_load(yaml_input)
    
    # data is likely a dict: {
    #   'fileFormatVersion': 2,
    #   'guid': 'f54d1bd14bd3ca042bd867b519fee8cc',
    #   'folderAsset': 'yes',
    #   'DefaultImporter': {
    #       'externalObjects': {},
    #       'userData': None,
    #       'assetBundleName': None,
    #       'assetBundleVariant': None
    #   }
    # }
    
    print("[Original Data]:", data)

    # Example: update the GUID
    data['guid'] = "1234567890abcdef1234567890abcdef"  # a new 32-char hex string
    
    # Optionally set an assetBundleName
    if 'DefaultImporter' in data and isinstance(data['DefaultImporter'], dict):
        data['DefaultImporter']['assetBundleName'] = "my_bundle"
    
    # Dump updated data back to YAML
    updated_yaml = yaml.dump(data, sort_keys=False)
    
    print("\n[Updated YAML]:\n")
    print(updated_yaml)

if __name__ == "__main__":
    main()
Explanation of Key Points
yaml.safe_load(...): Safely parse the .meta file.
Access & Modify
data['guid'] or data['DefaultImporter']['assetBundleName']. Re-dump with yaml.dump(...). By default, PyYAML might reorder keys if you don’t set sort_keys=False. Note: Unity generally regenerates or at least re-checks .meta files if you open the Editor. Changing a GUID can break references. Make sure you only do so if you know the ramifications. Usually, we keep the same GUID to preserve references.

4. Edge Cases & Potential Problems Changing GUID: This may cause Unity to treat the asset/folder as new, losing references in scenes or prefabs that pointed to the old GUID. Null vs. empty: The snippet uses empty lines for userData etc. PyYAML might parse them as None. That’s normal. If you rely on preserving empty lines exactly, you’ll have to manually re-inject them or store them as strings. File Name: .meta files must have the exact same name plus .meta extension as the asset/folder they describe. If you rename them, references can break. Conclusion
You can parse and manipulate a Unity .meta file just like any other YAML. Simply load it with PyYAML, adjust fields as needed, and write out the updated content. However, be cautious when changing fields like guid. That can break references across your Unity project. If you’re just wanting to set assetBundleName, assetBundleVariant, or userData, it’s typically safe.